### PR TITLE
Changed url to html_url for git-repo-url

### DIFF
--- a/.tekton/events/trigger_binding.yaml
+++ b/.tekton/events/trigger_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   params:
   - name: git-repo-url
-    value: $(body.repository.url)
+    value: $(body.repository.html_url)
   - name: git-repo-name
     value: $(body.repository.name)
   - name: git-revision


### PR DESCRIPTION
### Purpose

Trigger stopped working becasue the GitHub payload must have changed. The proper `git-repo-url` parameter is `$(body.repository.html_url)`

### Changes

- Changed `$(body.repository.url)` in `TriggerBinding` to `$(body.repository.html_url)` for GitHub payload
